### PR TITLE
scrollviews on all full screen modals; changed order of items in edit location form

### DIFF
--- a/app/screens/EditLocationDetails.js
+++ b/app/screens/EditLocationDetails.js
@@ -72,12 +72,12 @@ class EditLocationDetails extends Component {
                             <Text style={s.preview}>{phone}</Text>
                             <Text style={s.title}>Website</Text>
                             <Text style={s.preview}>{website}</Text>
+                            <Text style={s.title}>Location Notes</Text>
+                            <Text style={s.preview}>{description}</Text>
                             <Text style={s.title}>Location Type</Text>
                             <Text style={s.preview}>{typeof selectedLocationType === 'number' ? locationTypes.filter(type => type.id === selectedLocationType).map(type => type.name) : 'None Selected'}</Text>
                             <Text style={s.title}>Operator</Text>
                             <Text style={s.preview}>{typeof selectedOperatorId === 'number' ? operators.filter(operator => operator.id === selectedOperatorId).map(operator => operator.name) : 'None Selected'}</Text>
-                            <Text style={s.title}>Location Notes</Text>
-                            <Text style={s.preview}>{description}</Text>
                             <Button
                                 title={'Confirm Details'}
                                 onPress={() => this.confirmEditLocationDetails()}
@@ -122,6 +122,17 @@ class EditLocationDetails extends Component {
                                 returnKeyType="done"
                                 placeholder={website || 'http://...'}
                             />
+                            <Text style={s.title}>Location Notes</Text>
+                            <TextInput
+                                multiline={true}
+                                numberOfLines={4}
+                                style={[{padding:5,height: 100},s.textInput]}
+                                onChangeText={description => this.setState({ description })}
+                                underlineColorAndroid='transparent'
+                                value={description}
+                                placeholder={description || 'Location description...'}
+                                textAlignVertical='top'
+                            />
                             <Text style={s.title}>Location Type</Text>
                             <Picker style={s.pickerbg}
                                 selectedValue={selectedLocationType}
@@ -137,18 +148,7 @@ class EditLocationDetails extends Component {
                                 {operators.map(m => (
                                     <Picker.Item label={m.name} value={m.id} key={m.id} />
                                 ))}
-                            </Picker>
-                            <Text style={s.title}>Location Notes</Text>
-                            <TextInput
-                                multiline={true}
-                                numberOfLines={4}
-                                style={[{padding:5,height: 100},s.textInput]}
-                                onChangeText={description => this.setState({ description })}
-                                underlineColorAndroid='transparent'
-                                value={description}
-                                placeholder={description || 'Location description...'}
-                                textAlignVertical='top'
-                            />
+                            </Picker>                            
                             <Button
                                 title={'Submit Location Details'}
                                 onPress={() => this.setState({ showEditLocationDetailsModal: true })}

--- a/app/screens/FindMachine.js
+++ b/app/screens/FindMachine.js
@@ -75,9 +75,10 @@ class FindMachine extends Component {
                 <Modal
                     visible={this.state.showModal}
                     onRequestClose={()=>{}}
+                    transparent={false}
                 >
                     <TouchableWithoutFeedback onPress={ () => { DismissKeyboard() } }>
-                        <View style={{paddingTop: 50}}>
+                        <ScrollView style={{paddingTop: 50}}>
                             <Text style={{textAlign:'center',marginTop:10,marginLeft:15,marginRight:15,fontSize: 18}}>{`Add ${this.state.machineName} to ${this.props.location.location.name}?`}</Text>                
                             <Button 
                                 title={'Add'}
@@ -107,7 +108,7 @@ class FindMachine extends Component {
                                 textAlignVertical='top'
                                 underlineColorAndroid='transparent'
                             />
-                        </View>
+                        </ScrollView>
                     </TouchableWithoutFeedback>
                 </Modal>
                 <ScrollView>

--- a/app/screens/MachineDetails.js
+++ b/app/screens/MachineDetails.js
@@ -91,7 +91,7 @@ class MachineDetails extends Component {
                     onRequestClose={()=>{}}
                 >
                     <TouchableWithoutFeedback onPress={ () => { DismissKeyboard() } }>
-                        <View style={{paddingTop: 50}}>
+                        <ScrollView style={{paddingTop: 50}}>
                             <Text style={{textAlign:'center',marginBottom:10,marginLeft:15,marginRight:15,fontSize: 18}}>{`Comment on ${machineName} at ${location.name}!`}</Text>
                             <TextInput
                                 multiline={true}
@@ -123,7 +123,7 @@ class MachineDetails extends Component {
                                 style={{borderRadius: 50}}
                                 containerStyle={[{borderRadius:50},s.margin10]}
                             />
-                        </View>
+                        </ScrollView>
                     </TouchableWithoutFeedback>
                 </Modal>
                 <Modal
@@ -133,7 +133,7 @@ class MachineDetails extends Component {
                     onRequestClose={()=>{}}
                 >
                     <TouchableWithoutFeedback onPress={ () => { DismissKeyboard() } }>
-                        <View style={{paddingTop: 50}}>
+                        <ScrollView style={{paddingTop: 50}}>
                             <Text style={{textAlign:'center',marginBottom:10,marginLeft:15,marginRight:15,fontSize: 18}}>{`Add your high score to ${machineName} at ${location.name}!`}</Text>
                             <TextInput 
                                 style={[{height: 40,textAlign:'center'},s.textInput]}
@@ -164,7 +164,7 @@ class MachineDetails extends Component {
                                 style={{borderRadius: 50}}
                                 containerStyle={[{borderRadius:50},s.margin10]}
                             />
-                        </View>
+                        </ScrollView>
                     </TouchableWithoutFeedback>
                 </Modal>
                 {this.state.showRemoveMachineModal && <RemoveMachineModal closeModal={() => this.setState({showRemoveMachineModal: false})} />}


### PR DESCRIPTION
The location description was the last item in the edit location form, but that meant the keyboard covered it up when you typed. So I moved it up - seemed like the easiest solution.

And I made all full screen modals scrollview. I think scrollview is nice, even when you don't actually need to scroll. It just feels nicer to be able to pull the page up/down.