### PR TITLE
Hotfix/style tweaks

### DIFF
--- a/app/screens/Map.js
+++ b/app/screens/Map.js
@@ -101,7 +101,7 @@ class Map extends Component {
 
     async componentDidMount(){
         this.props.getCurrentLocation()
-        await Font.loadAsync({'FontAwesome': require('@expo/vector-icons/fonts/FontAwesome.ttf')})
+        await Font.loadAsync({'MaterialIcons': require('@expo/vector-icons/fonts/MaterialIcons.ttf')})
         this.setState({ fontAwesomeLoaded: true })
     }
 
@@ -211,8 +211,8 @@ class Map extends Component {
                     </MapView>
                     {fontAwesomeLoaded ? <Icon
                         raised
-                        name='location-arrow'
-                        type='font-awesome'
+                        name='gps-fixed'
+                        type='material'
                         color='#1e9dff'
                         containerStyle={{position:'absolute',bottom:0,right:0}}
                         size={24}

--- a/app/screens/Map.js
+++ b/app/screens/Map.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Font } from 'expo'
-import openMap from 'react-native-open-maps';
 import { 
     ActivityIndicator,
     Platform,

--- a/app/screens/Map.js
+++ b/app/screens/Map.js
@@ -39,7 +39,7 @@ class Map extends Component {
         this.prevRegion = {}
 
         this.state ={ 
-            fontMaterialLoaded: false,
+            materialIconsLoaded: false,
             showNoLocationTrackingModal: false,
             maxedOutZoom: false,
         }
@@ -102,7 +102,7 @@ class Map extends Component {
     async componentDidMount(){
         this.props.getCurrentLocation()
         await Font.loadAsync({'MaterialIcons': require('@expo/vector-icons/fonts/MaterialIcons.ttf')})
-        this.setState({ fontMaterialLoaded: true })
+        this.setState({ materialIconsLoaded: true })
     }
 
     UNSAFE_componentWillReceiveProps(props) {
@@ -123,7 +123,7 @@ class Map extends Component {
         } = this.props
         
         const { 
-            fontMaterialLoaded, 
+            materialIconsLoaded, 
             showNoLocationTrackingModal 
         } = this.state
         
@@ -209,7 +209,7 @@ class Map extends Component {
                             </MapView.Marker>
                         ))}
                     </MapView>
-                    {fontMaterialLoaded ? <Icon
+                    {materialIconsLoaded ? <Icon
                         raised
                         name='gps-fixed'
                         type='material'

--- a/app/screens/Map.js
+++ b/app/screens/Map.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Font } from 'expo'
+import openMap from 'react-native-open-maps';
 import { 
     ActivityIndicator,
     Platform,
@@ -102,6 +103,7 @@ class Map extends Component {
     async componentDidMount(){
         this.props.getCurrentLocation()
         await Font.loadAsync({'MaterialIcons': require('@expo/vector-icons/fonts/MaterialIcons.ttf')})
+        await Font.loadAsync({'Material Icons': require('@expo/vector-icons/fonts/MaterialIcons.ttf')})
         this.setState({ materialIconsLoaded: true })
     }
 

--- a/app/screens/Map.js
+++ b/app/screens/Map.js
@@ -39,7 +39,7 @@ class Map extends Component {
         this.prevRegion = {}
 
         this.state ={ 
-            fontAwesomeLoaded: false,
+            fontMaterialLoaded: false,
             showNoLocationTrackingModal: false,
             maxedOutZoom: false,
         }
@@ -102,7 +102,7 @@ class Map extends Component {
     async componentDidMount(){
         this.props.getCurrentLocation()
         await Font.loadAsync({'MaterialIcons': require('@expo/vector-icons/fonts/MaterialIcons.ttf')})
-        this.setState({ fontAwesomeLoaded: true })
+        this.setState({ fontMaterialLoaded: true })
     }
 
     UNSAFE_componentWillReceiveProps(props) {
@@ -123,7 +123,7 @@ class Map extends Component {
         } = this.props
         
         const { 
-            fontAwesomeLoaded, 
+            fontMaterialLoaded, 
             showNoLocationTrackingModal 
         } = this.state
         
@@ -209,7 +209,7 @@ class Map extends Component {
                             </MapView.Marker>
                         ))}
                     </MapView>
-                    {fontAwesomeLoaded ? <Icon
+                    {fontMaterialLoaded ? <Icon
                         raised
                         name='gps-fixed'
                         type='material'


### PR DESCRIPTION
Change current location button to use gps-fixed icon from Material Icons instead of location-arrow from Font Awesome. This icon is more standardized for finding current location on Android than the arrow, which is more of an iOS style.