### PR TITLE
correct url for app link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/bpoore/pbm-react.svg?branch=master)](https://travis-ci.org/bpoore/pbm-react)
 
-<a href="https://pinballmap.com/app">Get the app for iOS and Android!</a>
+<a href="https://www.pinballmap.com/app">Get the app for iOS and Android!</a>
 
 ![alt-text](https://github.com/bpoore/pbm-react/blob/master/app/assets/images/t-shirt-logo.png)


### PR DESCRIPTION
What a first commit! 🎉 

I believe this could also be resolved by changing a setting on the DNS record or with the hosting provider to resolve without the `www.`.